### PR TITLE
SetCounter fix

### DIFF
--- a/drone_trees/flight_idioms.py
+++ b/drone_trees/flight_idioms.py
@@ -15,9 +15,11 @@ make sense: garbage in, garbage out.
 import py_trees
 from drone_trees import leaf_nodes as lf
 
+
 def safety_module(name="Safety Module",
                   check=py_trees.behaviours.Dummy(name="Safety Check"),
-                  fallback=py_trees.behaviours.Dummy(name="Fallback")
+                  fallback=py_trees.behaviours.Dummy(name="Fallback"),
+                  oneshot=False
                   ):
     """
     A standard tree for use in the flight_manager idiom as a global safety
@@ -46,6 +48,11 @@ def safety_module(name="Safety Module",
             clears.
             FAILURE would be worrying here and would stop the whole tree.
         The default is py_trees.behaviours.Dummy(name="Fallback").
+    oneshot : bool, optional
+            True encapsulates the fallback behaviour in a oneshot resulting
+            in an unrepeatable response.
+            False allows for a repeatable response.
+        The default is False
 
     Returns
     -------
@@ -53,7 +60,14 @@ def safety_module(name="Safety Module",
         Root node of the generated tree.
 
     """
-    node = py_trees.composites.Selector(name=name, children=[check, fallback])
+    if oneshot:
+        node = py_trees.composites.Selector(
+            name=name,
+            children=[check, py_trees.decorators.OneShot(fallback)])
+    else:
+        node = py_trees.composites.Selector(
+            name=name,
+            children=[check, fallback])
     return node
 
 

--- a/drone_trees/leaf_nodes.py
+++ b/drone_trees/leaf_nodes.py
@@ -207,13 +207,13 @@ class SetCounter(py_trees.behaviour.Behaviour):
 
     def update(self):
         cur_wpn = self._vehicle.commands.next 
-        if cur_wpn <= self._wpn:
+        if cur_wpn < self._wpn:
             self.feedback_message = 'Advancing WP counter from {} to {}'.format(cur_wpn,self._wpn)
             print(self.feedback_message)
             self._vehicle.commands.next = self._wpn
             return py_trees.common.Status.SUCCESS
         else:
-            self.feedback_message = 'Cannot move WP counter backwards from {} to {}'.format((cur_wpn,self._wpn))
+            self.feedback_message = 'Cannot move WP counter backwards from {} to {}'.format(cur_wpn,self._wpn)
             return py_trees.common.Status.FAILURE
             
 

--- a/examples/bridge/fly_bridge.py
+++ b/examples/bridge/fly_bridge.py
@@ -66,7 +66,8 @@ def behaviour_tree(vehicle):
     # safety check: return home via SAFTI point any time if battery <30%
     safety_low_battery = im.safety_module(name="Low battery",
                                           check=lf.BatteryLevelAbove(vehicle, 30),
-                                          fallback=mission_handler.go_safti(vehicle))
+                                          fallback=mission_handler.go_safti(vehicle),
+                                          oneshot=True)
 
     # minimum distance criterion not implemented here
     # TODO figure out how to get drone_kit SITL to launch with DISTANCE_SENSOR


### PR DESCRIPTION
`SetCounter` node cannot set to the current counter resolving #12. For redundancy, a onshot option is added to the safety idiom.