### PR TITLE
leg handler completion fix & Integration tests

### DIFF
--- a/examples/bridge/fly_bridge.py
+++ b/examples/bridge/fly_bridge.py
@@ -71,9 +71,9 @@ def behaviour_tree(vehicle):
 
     # minimum distance criterion not implemented here
     # TODO figure out how to get drone_kit SITL to launch with DISTANCE_SENSOR
-    # safety_avoidance = im.safety_module(name="Collision avoidance", 
-    #                                     check=lf.CheckDistance(vehicle, 2, 2.),
-    #                                     fallback=mh.go_safti(vehicle))
+    safety_avoidance = im.safety_module(name="Collision avoidance", 
+                                        check=lf.CheckDistance(vehicle, 1, 2.),
+                                        fallback=mission_handler.go_safti(vehicle))
 
     # safety check: come home via SAFTI any time if EKF bad
     safety_ekf = im.safety_module(name="EKF health", 
@@ -103,7 +103,8 @@ def behaviour_tree(vehicle):
     root_node = im.flight_manager(vehicle,
                                   preflight=preflight_behaviours,
                                   safety=[safety_ekf,
-                                          safety_low_battery],
+                                          safety_low_battery,
+                                          safety_avoidance],
                                   legs=[leg_3_5,
                                         leg_5_7,
                                         leg_7_9,

--- a/examples/bridge/fly_bridge.py
+++ b/examples/bridge/fly_bridge.py
@@ -86,16 +86,20 @@ def behaviour_tree(vehicle):
     # TODO get SITL to mimic rangefinder and put clearance checks in
     # proceed from WP 3 to 5 if battery > 80%
     leg_3_5 = im.leg_handler(vehicle, 3, 5, preconds=[lf.CheckGPS(vehicle, 2),
-                                                      lf.BatteryLevelAbove(vehicle, 80)])
+                                                      lf.BatteryLevelAbove(vehicle, 80),
+                                                      lf.CheckDistance(vehicle, 1, 45.)])
     # proceed from WP 5 to 7 if battery > 80%
     leg_5_7 = im.leg_handler(vehicle, 5, 7, preconds=[lf.CheckGPS(vehicle, 2),
-                                                      lf.BatteryLevelAbove(vehicle, 70)])
+                                                      lf.BatteryLevelAbove(vehicle, 70),
+                                                      lf.CheckDistance(vehicle, 1, 15.)])
     # proceed from WP 7 to 9 if battery > 60%
     leg_7_9 = im.leg_handler(vehicle, 7, 9, preconds=[lf.CheckGPS(vehicle, 2),
-                                                      lf.BatteryLevelAbove(vehicle, 60)])
+                                                      lf.BatteryLevelAbove(vehicle, 60),
+                                                      lf.CheckDistance(vehicle, 1, 8.)])
     # proceed from WP 9 to 11 if battery > 50%
     leg_9_11 = im.leg_handler(vehicle, 9, 11, preconds=[lf.CheckGPS(vehicle, 2),
-                                                        lf.BatteryLevelAbove(vehicle, 50)])
+                                                        lf.BatteryLevelAbove(vehicle, 50),
+                                                        lf.CheckDistance(vehicle, 1, 4.)])
     # proceed from WP 11 to 12 with no preconditions
     leg_11_12 = im.leg_handler(vehicle, 11, 12)
 

--- a/examples/bridge/fly_bridge.py
+++ b/examples/bridge/fly_bridge.py
@@ -96,7 +96,9 @@ def behaviour_tree(vehicle):
     # proceed from WP 9 to 11 if battery > 50%
     leg_9_11 = im.leg_handler(vehicle, 9, 11, preconds=[lf.CheckGPS(vehicle, 2),
                                                         lf.BatteryLevelAbove(vehicle, 50)])
-    
+    # proceed from WP 11 to 12 with no preconditions
+    leg_11_12 = im.leg_handler(vehicle, 11, 12)
+
     # combine all modules into a single flight manager behavour tree
     root_node = im.flight_manager(vehicle,
                                   preflight=preflight_behaviours,
@@ -105,7 +107,8 @@ def behaviour_tree(vehicle):
                                   legs=[leg_3_5,
                                         leg_5_7,
                                         leg_7_9,
-                                        leg_9_11])
+                                        leg_9_11,
+                                        leg_11_12])
     
     return root_node
     


### PR DESCRIPTION
Proposed fix for #14 
- Mission Manager now has an "Is Mode Auto" guard as a robustness measure for pilot mode change
- Added a no precond option to the transition handler
- Added an extra transition handler from 11 (SAFTI) to 12 in fly_bridge
- Leg handler completion policy is changed from SuccessOnAll to SuccessOnSelected. The selected child is the last transition (11 to 12 in fly_bridge which means its past SAFTI) 

Added collision avoidance and clearance check to `fly_bridge` example

Integration test for the following safety behaviours #9 
- low battery: Vehicle is held at waypoint 2 until battery level drops below 36%.
- collision avoidance: The lidar reading at waypoint 7 is reduced below the safety limit of 2m triggering a jump to safti response.
